### PR TITLE
Refresh README presentation and terminal animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,32 @@
+<div align="center">
+
 # personagent
 
+<p><strong>A persona agent that knows how to talk — and when not to.</strong></p>
+
+Deployable in group chats and DMs. Grounded in the room, selective by design,<br>
+and able to learn from reactions without letting one noisy signal rewrite its character.
+
+[**English**](README.md) · [简体中文](README.zh-CN.md)
+
 [![CI](https://github.com/wangkant/personagent/actions/workflows/ci.yml/badge.svg)](https://github.com/wangkant/personagent/actions/workflows/ci.yml)
-[![Latest release](https://img.shields.io/github/v/release/wangkant/personagent?display_name=tag&sort=semver)](https://github.com/wangkant/personagent/releases)
-[![Tested on Python 3.10, 3.11, 3.12](https://img.shields.io/badge/tested-Python%203.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://www.python.org/downloads/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Latest release](https://img.shields.io/github/v/release/wangkant/personagent?display_name=tag&sort=semver&color=6f42c1)](https://github.com/wangkant/personagent/releases)
+[![Python 3.10–3.12](https://img.shields.io/badge/Python-3.10%E2%80%933.12-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-2f855a.svg)](LICENSE)
 
-**English** · [简体中文](README.zh-CN.md)
+[**Quick start**](#quick-start) · [Why it is different](#why-personagent) · [Deploy](#deployment-paths) · [Architecture](#architecture) · [Configure](#configuration)
 
-> A deployable, self-evolving persona agent for group chats and direct messages.
+</div>
 
-`personagent` turns any OpenAI-compatible chat model into a selective conversational persona: it understands the room, can choose not to reply, uses images and stickers as part of its voice, and learns from real reactions without letting a single noisy signal rewrite its behaviour.
+<a href="#quick-start">
+  <img src="assets/demo.svg" alt="personagent selectively replies or stays silent after a structured decision" width="100%">
+</a>
 
-It runs locally in a terminal, directly on QQ through OneBot v11, or across Telegram, Discord, Slack, Lark, and KOOK through the bundled AstrBot gateway.
-
-[![personagent terminal demo](assets/demo.svg)](#quick-start)
-
-## Why personagent
-
-Most group-chat bots are permanently on duty: formal, eager, and visibly assistant-shaped. `personagent` is built around a different operating model.
-
-| Capability | What it means in practice |
-|---|---|
-| **Persona-first conversation** | Register, relationships, conversational position, intent, memory, and the option to return `PASS` are part of the core reply path. |
-| **Guarded self-evolution** | Reactions become append-only evidence. Only corroborated, promoted candidates can influence future replies; promotion is auditable and reversible. |
-| **Fail-closed output boundary** | The model returns structured JSON. Parsing, semantic filters, character policy, and delivery checks run before anything reaches a chat. |
-| **Multimodal context** | Images, stickers, URLs, Bilibili/YouTube metadata, and share cards are turned into usable context instead of opaque attachments. |
-| **Vendor-neutral models** | Chat, judge, evaluation, and vision calls use OpenAI-compatible endpoints over HTTP; no provider SDK is required at runtime. |
-| **Operational controls** | Authenticated webhooks, replay protection, request limits, persistent deduplication, health checks, isolated runtime state, and cross-platform CI are included. |
-
-**Project status:** beta. Versioned releases follow Semantic Versioning; behavioural and storage changes are documented in the [changelog](CHANGELOG.md). The current release is suitable for controlled personal deployments, but operators remain responsible for platform-policy and account risk. Read the [deployment disclaimer](DISCLAIMER.md) before connecting a third-party IM client.
+`personagent` turns any OpenAI-compatible chat model into a situated conversational persona. It can run locally in a terminal, directly on QQ through OneBot v11, or across Telegram, Discord, Slack, Lark, and KOOK through the bundled AstrBot gateway.
 
 ## Quick start
 
-Requirements: Git, Python 3.10+, and one OpenAI-compatible API key. QQ and NapCat are not required for the local trial. CI currently covers Python 3.10, 3.11, and 3.12.
+You need Git, Python 3.10+, and one OpenAI-compatible API key. The local trial does not require QQ, NapCat, or another messaging adapter.
 
 ```bash
 git clone https://github.com/wangkant/personagent.git
@@ -40,9 +34,10 @@ cd personagent
 python quickstart.py
 ```
 
-The idempotent setup wizard creates `.venv`, installs dependencies, writes `.env`, optionally verifies the model endpoint, creates a persona file, and offers to start the terminal trial. It supports DeepSeek, Kimi, OpenAI, Ollama, and custom OpenAI-compatible endpoints.
+The setup wizard creates `.venv`, installs dependencies, writes `.env`, optionally verifies the model endpoint, creates a persona file, and offers to open the terminal trial. It is safe to run again and supports DeepSeek, Kimi, OpenAI, Ollama, and custom OpenAI-compatible endpoints.
 
-To return to the trial later:
+<details>
+<summary><strong>Open the terminal trial again or bootstrap without prompts</strong></summary>
 
 ```bash
 # macOS / Linux
@@ -52,15 +47,31 @@ To return to the trial later:
 # Windows
 .venv\Scripts\python.exe try_chat.py
 .venv\Scripts\python.exe try_chat.py --lang zh
-```
 
-The terminal uses the same persona, prompt assembly, retrieval, model-output parser, and reply validator as a live deployment. Use `--owner` to test the configured owner relationship and `--name <name>` to set the speaker name.
-
-For unattended bootstrap in CI or provisioning scripts:
-
-```bash
+# CI / provisioning
 python quickstart.py --no-input
 ```
+
+The trial uses the same persona, prompt assembly, retrieval, output parser, and reply validator as a live deployment. Add `--owner` to test the configured owner relationship or `--name <name>` to choose the speaker.
+
+</details>
+
+## Why personagent
+
+Most group-chat bots are permanently on duty: formal, eager, and visibly assistant-shaped. `personagent` is built around the social position of a participant instead.
+
+| **Situated persona** | **Selective by design** |
+|---|---|
+| Register, relationships, conversational position, intent, and scoped memory live in the core reply path. | `PASS` is a first-class outcome. The agent can decide that silence fits the room better than another message. |
+| **Learning behind a gate** | **Media as context** |
+| Reactions become append-only evidence; only corroborated, promoted candidates can affect future replies, and every promotion is reversible. | Images, stickers, URLs, videos, and share cards become usable context and can form part of the persona's voice. |
+
+### Production-minded by default
+
+- **Fail-closed output boundary:** structured model output is parsed, filtered, checked against the character policy, and validated before delivery.
+- **Vendor-neutral and operable:** chat, judge, evaluation, and vision calls use OpenAI-compatible HTTP endpoints; authenticated webhooks, replay protection, limits, persistent deduplication, health checks, isolated runtime state, and cross-platform CI are included.
+
+> **Beta:** versioned releases follow Semantic Versioning, and behavioural or storage changes are recorded in the [changelog](CHANGELOG.md). Controlled personal deployments are supported, but platform-policy and account risk remain the operator's responsibility. Read the [deployment disclaimer](DISCLAIMER.md) before connecting a third-party IM client.
 
 ## Deployment paths
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,38 +1,32 @@
+<div align="center">
+
 # personagent
 
+<p><strong>一个知道怎么说话，也知道什么时候不该说话的人设 Agent。</strong></p>
+
+可部署于群聊和私聊，理解聊天现场，默认有选择地回应；<br>
+能够从真实反应中学习，但不会让一次噪声反馈直接改写自己的性格。
+
+[English](README.md) · [**简体中文**](README.zh-CN.md)
+
 [![CI](https://github.com/wangkant/personagent/actions/workflows/ci.yml/badge.svg)](https://github.com/wangkant/personagent/actions/workflows/ci.yml)
-[![最新版本](https://img.shields.io/github/v/release/wangkant/personagent?display_name=tag&sort=semver)](https://github.com/wangkant/personagent/releases)
-[![已测试 Python 3.10、3.11、3.12](https://img.shields.io/badge/tested-Python%203.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://www.python.org/downloads/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![最新版本](https://img.shields.io/github/v/release/wangkant/personagent?display_name=tag&sort=semver&color=6f42c1)](https://github.com/wangkant/personagent/releases)
+[![Python 3.10–3.12](https://img.shields.io/badge/Python-3.10%E2%80%933.12-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-2f855a.svg)](LICENSE)
 
-[English](README.md) · **简体中文**
+[**快速开始**](#快速开始) · [为什么不同](#为什么选择-personagent) · [部署](#部署方式) · [架构](#架构) · [配置](#配置)
 
-> 面向群聊与私聊、可部署、可自进化的人设 Agent。
+</div>
 
-`personagent` 可以把任意 OpenAI 兼容聊天模型变成一个有选择性的人设角色：它理解聊天现场，知道什么时候不该接话，把图片和表情包当作表达的一部分，还能从真实反应中学习，同时避免一次噪声反馈直接改写自身行为。
+<a href="#快速开始">
+  <img src="assets/demo.svg" alt="personagent 经过结构化决策后选择回复或保持沉默" width="100%">
+</a>
 
-它既可以在终端本地运行，也可以通过 OneBot v11 直接接入 QQ，或借助仓库内置的 AstrBot 网关接入 Telegram、Discord、Slack、飞书和 KOOK。
-
-[![personagent 终端演示](assets/demo.svg)](#快速开始)
-
-## 为什么选择 personagent
-
-大多数群聊机器人始终处于“值班”状态：正式、积极、明显像一个助理。`personagent` 从底层采用了另一套运行方式。
-
-| 能力 | 实际含义 |
-|---|---|
-| **人设优先的对话** | 语域、关系、现场位置、意图、记忆，以及返回 `PASS` 保持沉默，都是核心回复链路的一部分。 |
-| **有门控的自进化** | 用户反应先成为只追加的证据。只有经过交叉验证并晋升的候选项才能影响后续回复，所有晋升都可审计、可撤销。 |
-| **失败即关闭的输出边界** | 模型返回结构化 JSON；解析、语义过滤、字符策略和投递检查全部通过后，内容才会进入聊天。 |
-| **多模态上下文** | 图片、表情包、URL、Bilibili/YouTube 元数据与分享卡片会被转换成可用上下文，而不是作为不透明附件。 |
-| **模型供应商无关** | 聊天、裁决、评估和视觉调用都通过 OpenAI 兼容 HTTP 接口完成，运行时不依赖厂商 SDK。 |
-| **完整的运维控制** | 包含 Webhook 鉴权、重放防护、请求限流、持久化去重、健康检查、运行数据隔离和跨平台 CI。 |
-
-**项目状态：** Beta。版本发布遵循语义化版本规范，行为与存储变更会记录在[更新日志](CHANGELOG.md)中。当前版本适合受控的个人部署，但平台政策与账号风险仍由部署者承担。连接第三方 IM 客户端前请阅读[部署免责声明](DISCLAIMER.md)。
+`personagent` 可以把任意 OpenAI 兼容聊天模型变成一个真正处在对话现场中的人设角色。它既能在终端本地运行，也能通过 OneBot v11 直接接入 QQ，或借助仓库内置的 AstrBot 网关接入 Telegram、Discord、Slack、飞书和 KOOK。
 
 ## 快速开始
 
-环境要求：Git、Python 3.10+，以及一个 OpenAI 兼容 API Key。本地试用不需要 QQ 或 NapCat。CI 当前覆盖 Python 3.10、3.11 和 3.12。
+你只需要 Git、Python 3.10+，以及一个 OpenAI 兼容 API Key。本地试用不需要 QQ、NapCat 或其他消息平台适配器。
 
 ```bash
 git clone https://github.com/wangkant/personagent.git
@@ -40,9 +34,10 @@ cd personagent
 python quickstart.py
 ```
 
-这个可重复执行的配置向导会创建 `.venv`、安装依赖、写入 `.env`、按需验证模型接口、创建人设文件，并询问是否直接进入终端试用。它支持 DeepSeek、Kimi、OpenAI、Ollama 和自定义 OpenAI 兼容接口。
+配置向导会创建 `.venv`、安装依赖、写入 `.env`、按需验证模型接口、创建人设文件，并询问是否直接进入终端试用。它可以安全地重复运行，支持 DeepSeek、Kimi、OpenAI、Ollama 和自定义 OpenAI 兼容接口。
 
-以后再次进入试用：
+<details>
+<summary><strong>再次进入终端试用，或进行无交互初始化</strong></summary>
 
 ```bash
 # macOS / Linux
@@ -52,15 +47,31 @@ python quickstart.py
 # Windows
 .venv\Scripts\python.exe try_chat.py
 .venv\Scripts\python.exe try_chat.py --lang zh
-```
 
-终端试用与线上部署共用相同的人设、Prompt 组装、检索、模型输出解析和回复验证链路。使用 `--owner` 测试配置好的主人关系，使用 `--name <名字>` 指定当前说话者。
-
-在 CI 或自动化部署脚本中进行无交互初始化：
-
-```bash
+# CI / 自动化部署
 python quickstart.py --no-input
 ```
+
+终端试用与线上部署共用相同的人设、Prompt 组装、检索、输出解析和回复验证链路。使用 `--owner` 测试配置好的主人关系，或用 `--name <名字>` 指定当前说话者。
+
+</details>
+
+## 为什么选择 personagent
+
+大多数群聊机器人始终处于“值班”状态：正式、积极、明显像一个助理。`personagent` 的出发点则是成为聊天中的一个参与者。
+
+| **处在现场的人设** | **默认有选择地回应** |
+|---|---|
+| 语域、关系、现场位置、意图和有作用域的记忆都位于核心回复链路中。 | `PASS` 是一等结果；当沉默比再发一条消息更合适时，Agent 可以选择不接话。 |
+| **门控之后再学习** | **把媒体当作上下文** |
+| 用户反应先成为只追加证据；只有经过交叉验证并晋升的候选项才能影响后续回复，而且每次晋升都可以撤销。 | 图片、表情包、URL、视频和分享卡片都会变成可用上下文，也可以成为人设表达的一部分。 |
+
+### 默认具备生产防线
+
+- **失败即关闭的输出边界：** 模型的结构化输出会先经过解析、过滤、字符策略和投递验证，再进入聊天。
+- **供应商无关且便于运维：** 聊天、裁决、评估和视觉调用都使用 OpenAI 兼容 HTTP 接口；同时内置 Webhook 鉴权、重放防护、限流、持久化去重、健康检查、运行数据隔离和跨平台 CI。
+
+> **Beta：** 版本发布遵循语义化版本规范，行为与存储变更会记录在[更新日志](CHANGELOG.md)中。当前版本支持受控的个人部署，但平台政策与账号风险仍由部署者承担。连接第三方 IM 客户端前请阅读[部署免责声明](DISCLAIMER.md)。
 
 ## 部署方式
 

--- a/assets/demo.svg
+++ b/assets/demo.svg
@@ -1,190 +1,157 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="598" viewBox="0 0 820 598" role="img" aria-labelledby="title desc">
-  <title id="title">personagent animated protocol trace</title>
-  <desc id="desc">An illustrated two-turn terminal trace. Each user message stays on the main alignment. The model's complete JSON return is indented as an internal diagnostic block. The first reply reaches the main sent line; the second returns PASS, so the sent line remains empty.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="420" viewBox="0 0 920 420" role="img" aria-labelledby="title desc">
+  <title id="title">personagent animated selective reply trace</title>
+  <desc id="desc">An animated terminal trace alternates between two complete outcomes from the same persona-agent pipeline. One turn produces a natural reply and is sent. The other produces PASS and stays silent. The layout remains filled throughout the animation.</desc>
   <style>
-    svg {
-      --bg: #f8fafc;
-      --surface: #ffffff;
-      --ink: #172033;
-      --muted: #667085;
-      --line: #d9e2ec;
-      --blue: #1769aa;
-      --violet: #7047b8;
-      --violet-soft: #f3effb;
-      --mint: #087f5b;
-      --mint-soft: #eaf8f2;
-      --amber: #9a5b00;
-      --amber-soft: #fff5dc;
-    }
     text {
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
       dominant-baseline: middle;
       white-space: pre;
     }
-    .bg { fill: var(--bg); }
-    .surface { fill: var(--surface); }
-    .frame, .rule { stroke: var(--line); }
-    .ink { fill: var(--ink); }
-    .muted { fill: var(--muted); }
-    .user { fill: var(--blue); }
-    .model { fill: var(--violet); }
-    .model-panel {
-      fill: var(--violet-soft);
-      stroke: var(--line);
+    .bg { fill: #f6f7fb; }
+    .surface { fill: #ffffff; }
+    .frame, .rule { stroke: #dfe3ec; }
+    .ink { fill: #1d2433; }
+    .muted { fill: #687083; }
+    .violet { fill: #6842c2; }
+    .blue { fill: #1769aa; }
+    .green { fill: #087f5b; }
+    .amber { fill: #946000; }
+    .pipeline, .model-panel { fill: #f2edff; stroke: #dfe3ec; }
+    .reply-result { fill: #e9f8f1; }
+    .pass-result { fill: #fff5dc; }
+    .shadow { fill: #d7d9e3; opacity: .42; }
+    .scenario { animation: 14s steps(1, end) infinite; }
+    .scenario-reply { opacity: 1; animation-name: show-reply; }
+    .scenario-pass { opacity: 0; animation-name: show-pass; }
+    @keyframes show-reply {
+      0%, 49% { opacity: 1; }
+      50%, 99% { opacity: 0; }
+      100% { opacity: 1; }
     }
-    .sent-panel { fill: var(--mint-soft); }
-    .sent { fill: var(--mint); }
-    .pass-panel { fill: var(--amber-soft); }
-    .pass { fill: var(--amber); }
-    .row {
-      opacity: 0;
-      animation-duration: 18s;
-      animation-timing-function: steps(1, end);
-      animation-iteration-count: infinite;
+    @keyframes show-pass {
+      0%, 49% { opacity: 0; }
+      50%, 99% { opacity: 1; }
+      100% { opacity: 0; }
     }
-    .r0 { animation-name: r0; }
-    .r1 { animation-name: r1; }
-    .r2 { animation-name: r2; }
-    .r3 { animation-name: r3; }
-    .r4 { animation-name: r4; }
-    .r5 { animation-name: r5; }
-    .r6 { animation-name: r6; }
-    .r7 { animation-name: r7; }
-    .r8 { animation-name: r8; }
-    .r9 { animation-name: r9; }
-    .r10 { animation-name: r10; }
-    .r11 { animation-name: r11; }
-    .r12 { animation-name: r12; }
-    .r13 { animation-name: r13; }
-    .r14 { animation-name: r14; }
-    .r15 { animation-name: r15; }
-    .r16 { animation-name: r16; }
-    .r17 { animation-name: r17; }
-    @keyframes r0 { 0%,2%{opacity:0} 3%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r1 { 0%,6%{opacity:0} 7%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r2 { 0%,11%{opacity:0} 12%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r3 { 0%,17%{opacity:0} 18%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r4 { 0%,21%{opacity:0} 22%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r5 { 0%,25%{opacity:0} 26%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r6 { 0%,29%{opacity:0} 30%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r7 { 0%,33%{opacity:0} 34%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r8 { 0%,37%{opacity:0} 38%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r9 { 0%,43%{opacity:0} 44%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r10 { 0%,51%{opacity:0} 52%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r11 { 0%,57%{opacity:0} 58%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r12 { 0%,61%{opacity:0} 62%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r13 { 0%,65%{opacity:0} 66%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r14 { 0%,69%{opacity:0} 70%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r15 { 0%,73%{opacity:0} 74%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r16 { 0%,77%{opacity:0} 78%,94%{opacity:1} 98%,100%{opacity:0} }
-    @keyframes r17 { 0%,83%{opacity:0} 84%,94%{opacity:1} 98%,100%{opacity:0} }
+    .step { opacity: .88; animation: step-pulse 4.8s ease-in-out infinite; }
+    .step-2 { animation-delay: 1.2s; }
+    .step-3 { animation-delay: 2.4s; }
+    .step-4 { animation-delay: 3.6s; }
+    @keyframes step-pulse {
+      0%, 18% { opacity: 1; }
+      28%, 100% { opacity: .88; }
+    }
     .cursor { animation: blink 1.05s steps(1, end) infinite; }
-    @keyframes blink { 0%,49%{opacity:1} 50%,100%{opacity:0} }
+    @keyframes blink { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
     @media (prefers-color-scheme: dark) {
-      svg {
-        --bg: #0d1117;
-        --surface: #111821;
-        --ink: #e6edf3;
-        --muted: #8b949e;
-        --line: #30363d;
-        --blue: #58a6ff;
-        --violet: #bc8cff;
-        --violet-soft: #1c1726;
-        --mint: #56d49b;
-        --mint-soft: #10241d;
-        --amber: #e3b341;
-        --amber-soft: #2a210f;
-      }
+      .bg { fill: #0d1117; }
+      .surface { fill: #141a23; }
+      .frame, .rule, .pipeline, .model-panel { stroke: #30363d; }
+      .ink { fill: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .violet { fill: #bc8cff; }
+      .blue { fill: #58a6ff; }
+      .green { fill: #56d49b; }
+      .amber { fill: #e3b341; }
+      .pipeline, .model-panel { fill: #211a31; }
+      .reply-result { fill: #11271e; }
+      .pass-result { fill: #2a210f; }
+      .shadow { fill: #000000; }
     }
     @media (prefers-reduced-motion: reduce) {
-      .row { animation: none !important; opacity: 1; }
-      .cursor { animation: none !important; opacity: 1; }
+      .scenario, .step, .cursor { animation: none !important; }
+      .scenario-reply, .cursor { opacity: 1; }
+      .scenario-pass { opacity: 0; }
+      .step { opacity: .92; }
     }
   </style>
 
-  <rect class="bg" width="820" height="598" rx="10"/>
-  <rect class="surface" x="0.5" y="0.5" width="819" height="42" rx="9"/>
-  <rect class="frame" x="0.5" y="0.5" width="819" height="597" rx="9" fill="none"/>
-  <circle cx="22" cy="21" r="5.5" fill="#e66555"/>
-  <circle cx="40" cy="21" r="5.5" fill="#d99b22"/>
-  <circle cx="58" cy="21" r="5.5" fill="#28a36a"/>
-  <text class="muted" x="410" y="21" font-size="12.5" text-anchor="middle">try_chat.py · illustrated protocol trace</text>
-  <line class="rule" x1="0" y1="42" x2="820" y2="42"/>
+  <rect class="bg" width="920" height="420" rx="14"/>
+  <rect class="shadow" x="8" y="8" width="904" height="404" rx="13"/>
+  <rect class="surface" x="0.5" y="0.5" width="919" height="411" rx="13"/>
+  <rect class="frame" x="0.5" y="0.5" width="919" height="411" rx="13" fill="none"/>
 
-  <g class="row r0">
-    <text class="sent" x="20" y="66" font-size="12.5">$</text>
-    <text class="ink" x="46" y="66" font-size="13.5">python try_chat.py</text>
-  </g>
-  <text class="row r1 muted" x="20" y="92" font-size="12.5">internal JSON is expanded here · the real trial prints only reply, intent, and mem</text>
+  <rect class="surface" x="0.5" y="0.5" width="919" height="44" rx="13"/>
+  <line class="rule" x1="0" y1="44" x2="920" y2="44"/>
+  <circle cx="22" cy="22" r="5.5" fill="#e66555"/>
+  <circle cx="40" cy="22" r="5.5" fill="#d99b22"/>
+  <circle cx="58" cy="22" r="5.5" fill="#28a36a"/>
+  <text class="muted" x="460" y="22" font-size="12.5" text-anchor="middle">try_chat.py · selective reply trace</text>
 
-  <g class="row r2">
-    <text class="user" x="20" y="128" font-size="12.5">you</text>
-    <text class="ink" x="92" y="128" font-size="13.5">spent 3 hours on this and ctrl+z'd it into the void</text>
-  </g>
+  <text class="green" x="22" y="66" font-size="12.5">$</text>
+  <text class="ink" x="47" y="66" font-size="13.5">python try_chat.py</text>
+  <text class="muted" x="898" y="66" font-size="11.5" text-anchor="end">live agent boundary</text>
 
-  <g class="row r3" data-role="model-trace">
-    <rect class="model-panel" x="52" y="148" width="748" height="142" rx="7"/>
-    <line class="rule" x1="52" y1="148" x2="52" y2="290"/>
-    <text class="model" x="70" y="166" font-size="12.5">model</text>
-    <text class="muted" x="154" y="166" font-size="13.5">{</text>
+  <rect class="pipeline" x="20" y="84" width="880" height="42" rx="10"/>
+  <g class="step step-1">
+    <text class="violet" x="42" y="105" font-size="12.5">persona + room</text>
   </g>
-  <g class="row r4">
-    <text class="model" x="154" y="190" font-size="13">&quot;reasoning&quot;:</text>
-    <text class="ink" x="278" y="190" font-size="13">&quot;a beat of empathy, not a fix-it list&quot;,</text>
+  <text class="muted" x="235" y="105" font-size="14">→</text>
+  <g class="step step-2">
+    <text class="violet" x="272" y="105" font-size="12.5">structured decision</text>
   </g>
-  <g class="row r5">
-    <text class="model" x="154" y="214" font-size="13">&quot;intent&quot;:</text>
-    <text class="ink" x="278" y="214" font-size="13">&quot;vent&quot;,</text>
+  <text class="muted" x="485" y="105" font-size="14">→</text>
+  <g class="step step-3">
+    <text class="violet" x="522" y="105" font-size="12.5">validate</text>
   </g>
-  <g class="row r6">
-    <text class="model" x="154" y="238" font-size="13">&quot;reply&quot;:</text>
-    <text class="ink" x="278" y="238" font-size="13">&quot;rip. take five before you go back in&quot;,</text>
-  </g>
-  <g class="row r7">
-    <text class="model" x="154" y="262" font-size="13">&quot;mem&quot;:</text>
-    <text class="ink" x="278" y="262" font-size="13">&quot;&quot;</text>
-  </g>
-  <text class="row r8 muted" x="154" y="282" font-size="13.5">}</text>
-
-  <g class="row r9" data-role="sent">
-    <rect class="sent-panel" x="12" y="304" width="796" height="42" rx="7"/>
-    <text class="sent" x="20" y="326" font-size="12.5">sent</text>
-    <text class="ink" x="92" y="326" font-size="13.5">rip. take five before you go back in</text>
+  <text class="muted" x="647" y="105" font-size="14">→</text>
+  <g class="step step-4">
+    <text class="violet" x="684" y="105" font-size="12.5">send or stay silent</text>
   </g>
 
-  <g class="row r10">
-    <text class="user" x="20" y="370" font-size="12.5">you</text>
-    <text class="ink" x="92" y="370" font-size="13.5">D . e</text>
+  <rect class="shadow" x="24" y="146" width="876" height="240" rx="11"/>
+  <rect class="surface frame" x="20.5" y="142.5" width="879" height="239" rx="11"/>
+
+  <g class="scenario scenario-reply">
+    <circle cx="42" cy="164" r="5" fill="#28a36a"/>
+    <text class="green" x="57" y="164" font-size="12.5">REPLY</text>
+    <text class="muted" x="878" y="164" font-size="11.5" text-anchor="end">01 / a message belongs here</text>
+
+    <text class="blue" x="42" y="188" font-size="12">you</text>
+    <text class="ink" x="102" y="188" font-size="12.5">spent 3 hours on this and ctrl+z'd it into the void</text>
+
+    <rect class="model-panel" x="42" y="205" width="836" height="110" rx="8"/>
+    <text class="violet" x="58" y="224" font-size="12">model</text>
+    <text class="violet" x="146" y="224" font-size="12">reasoning</text>
+    <text class="ink" x="248" y="224" font-size="12.5">"a beat of empathy, not a fix-it list"</text>
+    <text class="violet" x="146" y="248" font-size="12">intent</text>
+    <text class="ink" x="248" y="248" font-size="12.5">"vent"</text>
+    <text class="violet" x="146" y="272" font-size="12">reply</text>
+    <text class="ink" x="248" y="272" font-size="12.5">"rip. take five before you go back in"</text>
+    <text class="violet" x="146" y="296" font-size="12">mem</text>
+    <text class="ink" x="248" y="296" font-size="12.5">""</text>
+
+    <rect class="reply-result" x="42" y="327" width="836" height="38" rx="8"/>
+    <text class="green" x="58" y="346" font-size="11.5">SENT</text>
+    <text class="ink" x="122" y="346" font-size="12.5">rip. take five before you go back in</text>
+    <text class="green cursor" x="854" y="346" font-size="12.5">█</text>
   </g>
 
-  <g class="row r11" data-role="model-trace">
-    <rect class="model-panel" x="52" y="390" width="748" height="142" rx="7"/>
-    <line class="rule" x1="52" y1="390" x2="52" y2="532"/>
-    <text class="model" x="70" y="408" font-size="12.5">model</text>
-    <text class="muted" x="154" y="408" font-size="13.5">{</text>
-  </g>
-  <g class="row r12">
-    <text class="model" x="154" y="432" font-size="13">&quot;reasoning&quot;:</text>
-    <text class="ink" x="278" y="432" font-size="13">&quot;noise — nothing here asks for a reply&quot;,</text>
-  </g>
-  <g class="row r13">
-    <text class="model" x="154" y="456" font-size="13">&quot;intent&quot;:</text>
-    <text class="ink" x="278" y="456" font-size="13">&quot;chat&quot;,</text>
-  </g>
-  <g class="row r14">
-    <text class="model" x="154" y="480" font-size="13">&quot;reply&quot;:</text>
-    <text class="pass" x="278" y="480" font-size="13">&quot;PASS&quot;,</text>
-  </g>
-  <g class="row r15">
-    <text class="model" x="154" y="504" font-size="13">&quot;mem&quot;:</text>
-    <text class="ink" x="278" y="504" font-size="13">&quot;&quot;</text>
-  </g>
-  <text class="row r16 muted" x="154" y="524" font-size="13.5">}</text>
+  <g class="scenario scenario-pass">
+    <circle cx="42" cy="164" r="5" fill="#d99b22"/>
+    <text class="amber" x="57" y="164" font-size="12.5">PASS</text>
+    <text class="muted" x="878" y="164" font-size="11.5" text-anchor="end">02 / silence fits the room</text>
 
-  <g class="row r17" data-role="sent">
-    <rect class="pass-panel" x="12" y="546" width="796" height="40" rx="7"/>
-    <text class="pass" x="20" y="567" font-size="12.5">sent</text>
-    <text class="pass" x="92" y="567" font-size="13.5">∅ · PASS keeps this turn inside the agent pipeline</text>
-    <text class="cursor sent" x="786" y="567" font-size="13">█</text>
+    <text class="blue" x="42" y="188" font-size="12">you</text>
+    <text class="ink" x="102" y="188" font-size="12.5">D . e</text>
+    <text class="muted" x="180" y="188" font-size="11.5">nothing here asks for a reply</text>
+
+    <rect class="model-panel" x="42" y="205" width="836" height="110" rx="8"/>
+    <text class="violet" x="58" y="224" font-size="12">model</text>
+    <text class="violet" x="146" y="224" font-size="12">reasoning</text>
+    <text class="ink" x="248" y="224" font-size="12.5">"noise — nothing here asks for a reply"</text>
+    <text class="violet" x="146" y="248" font-size="12">intent</text>
+    <text class="ink" x="248" y="248" font-size="12.5">"chat"</text>
+    <text class="violet" x="146" y="272" font-size="12">reply</text>
+    <text class="amber" x="248" y="272" font-size="12.5">"PASS"</text>
+    <text class="violet" x="146" y="296" font-size="12">mem</text>
+    <text class="ink" x="248" y="296" font-size="12.5">""</text>
+
+    <rect class="pass-result" x="42" y="327" width="836" height="38" rx="8"/>
+    <text class="amber" x="58" y="346" font-size="11.5">SILENT</text>
+    <text class="ink" x="122" y="346" font-size="12.5">∅  no outbound message · the decision stays inside the pipeline</text>
+    <text class="amber cursor" x="854" y="346" font-size="12.5">█</text>
   </g>
+
+  <text class="muted" x="460" y="401" font-size="11.5" text-anchor="middle">The expanded trace makes the decision visible; the real trial prints only reply, intent, and memory.</text>
 </svg>


### PR DESCRIPTION
## Summary

- redesign the terminal trace as a compact animation that alternates between complete REPLY and PASS states without reserving an empty lower half
- add a valid static first frame plus dark-mode and reduced-motion fallbacks
- reorganize the English and Chinese README introductions so Quick Start and the core product distinction are visible sooner
- keep the two language versions structurally aligned and preserve the existing technical documentation

## Validation

- parsed `assets/demo.svg` as XML and rasterized its static fallback at 920×420
- verified complementary animation states, dark-mode and reduced-motion rules
- verified the dimmed pipeline labels meet 4.5:1 contrast (4.56:1)
- rendered both READMEs and checked all local targets
- ran `git diff --check`

Runtime code is unchanged.